### PR TITLE
Remove transient storage use

### DIFF
--- a/contracts/CompliantContract.sol
+++ b/contracts/CompliantContract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.25;
+pragma solidity ^0.8;
 
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {SecurelyOwnableUpgradeable} from "./utils/SecurelyOwnableUpgradeable.sol";
@@ -10,14 +10,14 @@ import {ICompliance} from "./interfaces/ICompliance.sol";
 /// @notice This contract provides tools to enforce compliance rules
 /// @dev This abstract contract provides five modifiers and a few internal functions to enforce compliance rules
 abstract contract CompliantContract is SecurelyOwnableUpgradeable {
-    /// @notice A slot for the compliance full hash of the current transaction
-    /// @dev keccak256(abi.encode(uint256(keccak256("securely.storage.complianceFullHash")) - 1)) & ~bytes32(uint256(0xff))
-    uint private constant COMPLIANCE_FULL_HASH_SLOT = 0x5a919f7f4e3a2bc944388bf5f328e0afbc9dd7ca9d96b2c317ca3b97d9229400;
-
     /// @notice The Securely compliance contract address. It must be set before using the modifiers.
     /// @dev This contract is set by the owner and must implement the ICompliance interface.
     /// @dev Multiple dapps can share the same compliance contract.
     ICompliance public compliance;
+
+    /// @notice The compliance full hash of the current transaction
+    /// @dev It is reset at the end of each transaction
+    bytes32 internal complianceFullHash;
 
     constructor() initializer { __CompliantContract_init(); }
     function __CompliantContract_init() internal onlyInitializing {
@@ -34,7 +34,7 @@ abstract contract CompliantContract is SecurelyOwnableUpgradeable {
     /// @param value The value parameter associated to the transaction
     /// @param data An optional data parameter associated to the transaction
     /// @param enable A boolean to enable or disable the compliance check. Useful for dynamic compliance checking
-    modifier requiresGenericCallCompliance         (                                         uint256 value, bytes memory data, bool enable) { if (enable) { requireCompliance(compliance.computeGenericCallPartialHash          (block.chainid, msg.sig, msg.sender,      value, data));                                   } _; assembly { tstore(COMPLIANCE_FULL_HASH_SLOT, 0) } }
+    modifier requiresGenericCallCompliance         (                                         uint256 value, bytes memory data, bool enable) { if (enable) { requireCompliance(compliance.computeGenericCallPartialHash          (block.chainid, msg.sig, msg.sender,      value, data));                                   } _; complianceFullHash = 0; }
 
     /// @notice A modifier to require compliance for a native Eth transfer
     /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
@@ -43,7 +43,7 @@ abstract contract CompliantContract is SecurelyOwnableUpgradeable {
     /// @dev The to parameter is used for address screening purposes
     /// @param value The value parameter associated to the transaction
     /// @param enable A boolean to enable or disable the compliance check. Useful for dynamic compliance checking
-    modifier requiresEthTransferCompliance         (address from, address to,                uint256 value,                    bool enable) { if (enable) { requireCompliance(compliance.computeEthTransferPartialHash          (block.chainid, msg.sig, from, to,        value      )); payFees(from, address(0), value); } _; assembly { tstore(COMPLIANCE_FULL_HASH_SLOT, 0) } }
+    modifier requiresEthTransferCompliance         (address from, address to,                uint256 value,                    bool enable) { if (enable) { requireCompliance(compliance.computeEthTransferPartialHash          (block.chainid, msg.sig, from, to,        value      )); payFees(from, address(0), value); } _; complianceFullHash = 0; }
 
     /// @notice A modifier to require compliance for a native Eth transfer
     /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
@@ -53,7 +53,7 @@ abstract contract CompliantContract is SecurelyOwnableUpgradeable {
     /// @param value The value parameter associated to the transaction
     /// @param data Any data associated to the transaction that isn't already included, but uniquely identifies the transaction. e.g. an invoice ID
     /// @param enable A boolean to enable or disable the compliance check. Useful for dynamic compliance checking
-    modifier requiresEthTransferWithDataCompliance (address from, address to,                uint256 value, bytes memory data, bool enable) { if (enable) { requireCompliance(compliance.computeEthTransferWithDataPartialHash  (block.chainid, msg.sig, from, to,        value, data)); payFees(from, address(0), value); } _; assembly { tstore(COMPLIANCE_FULL_HASH_SLOT, 0) } }
+    modifier requiresEthTransferWithDataCompliance (address from, address to,                uint256 value, bytes memory data, bool enable) { if (enable) { requireCompliance(compliance.computeEthTransferWithDataPartialHash  (block.chainid, msg.sig, from, to,        value, data)); payFees(from, address(0), value); } _; complianceFullHash = 0; }
 
     /// @notice A modifier to require compliance for an ERC20 transfer
     /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
@@ -63,7 +63,7 @@ abstract contract CompliantContract is SecurelyOwnableUpgradeable {
     /// @param token The ERC20 token address
     /// @param value The value parameter associated to the transaction
     /// @param enable A boolean to enable or disable the compliance check. Useful for dynamic compliance checking
-    modifier requiresErc20TransferCompliance       (address from, address to, address token, uint256 value,                    bool enable) { if (enable) { requireCompliance(compliance.computeErc20TransferPartialHash        (block.chainid, msg.sig, from, to, token, value      )); payFees(from, token,      value); } _; assembly { tstore(COMPLIANCE_FULL_HASH_SLOT, 0) } }
+    modifier requiresErc20TransferCompliance       (address from, address to, address token, uint256 value,                    bool enable) { if (enable) { requireCompliance(compliance.computeErc20TransferPartialHash        (block.chainid, msg.sig, from, to, token, value      )); payFees(from, token,      value); } _; complianceFullHash = 0; }
 
     /// @notice A modifier to require compliance for an ERC20 transfer
     /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
@@ -74,20 +74,13 @@ abstract contract CompliantContract is SecurelyOwnableUpgradeable {
     /// @param value The value parameter associated to the transaction
     /// @param data Any data associated to the transaction that isn't already included, but uniquely identifies the transaction. e.g. an invoice ID
     /// @param enable A boolean to enable or disable the compliance check. Useful for dynamic compliance checking
-    modifier requiresErc20TransferAndDataCompliance(address from, address to, address token, uint256 value, bytes memory data, bool enable) { if (enable) { requireCompliance(compliance.computeErc20TransferWithDataPartialHash(block.chainid, msg.sig, from, to, token, value, data)); payFees(from, token,      value); } _; assembly { tstore(COMPLIANCE_FULL_HASH_SLOT, 0) } }
-
-    /// @notice Gets the compliance full hash
-    /// @dev This function is a helper to avoid using assembly code elsewhere
-    /// @return fullHash The compliance full hash
-    function complianceFullHash() internal view returns (bytes32 fullHash) {
-        assembly { fullHash := tload(COMPLIANCE_FULL_HASH_SLOT) }
-    }
+    modifier requiresErc20TransferAndDataCompliance(address from, address to, address token, uint256 value, bytes memory data, bool enable) { if (enable) { requireCompliance(compliance.computeErc20TransferWithDataPartialHash(block.chainid, msg.sig, from, to, token, value, data)); payFees(from, token,      value); } _; complianceFullHash = 0; }
 
     /// @notice Checks if the compliance is activated
     /// @dev Use this function to check if the compliance is currently activated
     /// @return activated true if the compliance is activated
     function complianceActivated() internal view returns (bool activated) {
-        activated = complianceFullHash() != 0;
+        activated = complianceFullHash != 0;
     }
 
     /// @notice A modifier to require the compliance to be activated
@@ -117,7 +110,6 @@ abstract contract CompliantContract is SecurelyOwnableUpgradeable {
     }
 
     function requireCompliance(bytes32 partialHash) private {
-        bytes32 fullHash = compliance.consumeCompliance(partialHash);
-        assembly { tstore(COMPLIANCE_FULL_HASH_SLOT, fullHash) }
+        complianceFullHash = compliance.consumeCompliance(partialHash);
     }
 }

--- a/contracts/examples/CompliantFunds.sol
+++ b/contracts/examples/CompliantFunds.sol
@@ -52,6 +52,6 @@ abstract contract CompliantFunds is CompliantContract {
     ) internal requiresComplianceActivated(true) {
         _payedAmounts[destination][msg.sender][currency] += netAmount;
         _payedAmounts[destination][address(0)][currency] += netAmount;
-        emit CompliantPayment(msg.sender, destination, currency, netAmount, complianceFullHash());
+        emit CompliantPayment(msg.sender, destination, currency, netAmount, complianceFullHash);
     }
 }


### PR DESCRIPTION
This optimization requires solidity 8.25, which can be a problem for some users.
We choose not to use it until transient storage is more widely used.

When the complianceFullHash is not used at all, the optimizer should remove the variable entirely, as it's internal and not public.