### PR TITLE
Jsonify compliance datas

### DIFF
--- a/contracts/interfaces/ICompliance.sol
+++ b/contracts/interfaces/ICompliance.sol
@@ -17,14 +17,6 @@ interface ICompliance is IFeeCollector {
     /// @notice The different statuses of a transaction
     enum Status {Approved, Expired, NotFound, Pending, Rejected}
 
-    /// @notice The details of a compliance check. A transaction can have multiple compliance checks
-    struct ComplianceDetail {
-        string complianceType;
-        string providerName;
-        string ref;
-        string data;
-    }
-
     /// @notice The compliance timestamps of a transaction
     /// @dev The registry timestamp is the timestamp at which the compliance was registered
     /// @dev The expiry timestamp is the timestamp at which the compliance expires
@@ -34,9 +26,9 @@ interface ICompliance is IFeeCollector {
     }
 
     event ApprovalRequired    (address indexed dapp, bytes32 indexed fullHash, bytes32 indexed partialHash);
-    event ComplianceRegistered(address indexed dapp, bytes32 indexed fullHash, ComplianceDetail[] complianceDetails);
+    event ComplianceRegistered(address indexed dapp, bytes32 indexed fullHash, string complianceDetails);
     event ComplianceVerdict   (address indexed dapp, bytes32 indexed fullHash, bool approved);
-    event ComplianceConsumed  (address indexed dapp, bytes32 indexed fullHash, ComplianceDetail[] complianceDetails);
+    event ComplianceConsumed  (address indexed dapp, bytes32 indexed fullHash, string complianceDetails);
 
     /// @notice Gets the compliance status of a transaction
     /// @param dapp The dapp address


### PR DESCRIPTION
As we do not make any check on compliance datas on-chain, a better way to store it is one big JSON string. It is more readable and much cheaper in gaz.
The current solution is the worst of both worlds. It's not flexible and it's costly.

Here is what happens when we store [["test1", "test2", "test3", "test4"], ["test5", "test6", "test7", "test8"], ["test9", "test10", "test11", "test12"]], where each line is a 32 bytes word:
```
[   0] 32 => the offset where the elements of the outer list start relative to the beginning of the outer list (here [32]) so [64]
[  32] 3 => the size of the outer list
[  64] 96 => the offset of the 1st element (["test1", "test2", "test3", "test4"]) relative to the beginning of the list (here [64]) so [160]
[  96] 480 => the offset of the 2nd element (["test5", "test6", "test7", "test8"]) relative to the beginning of the list (here [64]) so [544]
[ 128] 864 => the offset of the 3rd element (["test9", "test10", "test11", "test12"]) relative to the beginning of the list (here [64]) so [928]
[ 160] 128 => the offset of the 1st element of the sublist ("test1") relative to the beginning of the sublist (here [160]) so [288]
[ 192] 192 => the offset of the 2nd element of the sublist ("test2") relative to the beginning of the sublist (here [160]) so [352]
[ 224] 256 => the offset of the 3rd element of the sublist ("test3") relative to the beginning of the sublist (here [160]) so [416]
[ 256] 320 => the offset of the 4th element of the sublist ("test4") relative to the beginning of the sublist (here [160]) so [480]
[ 288] 5 => the size of the following string
[ 320] "test1"
[ 352] 5 => the size of the following string
[ 384] "test2"
[ 416] 5 => the size of the following string
[ 448] "test3"
[ 480] 5 => the size of the following string
[ 512] "test4"
[ 544] 128 => the offset of the 1st element of the sublist ("test5") relative to the beginning of the sublist (here [544]) so [672]
[ 576] 192 => the offset of the 2nd element of the sublist ("test6") relative to the beginning of the sublist (here [544]) so [736]
[ 608] 256 => the offset of the 3rd element of the sublist ("test7") relative to the beginning of the sublist (here [544]) so [800]
[ 640] 320 => the offset of the 4th element of the sublist ("test8") relative to the beginning of the sublist (here [544]) so [864]
[ 672] 5 => the size of the following string
[ 704] "test5"
[ 736] 5 => the size of the following string
[ 768] "test6"
[ 800] 5 => the size of the following string
[ 832] "test7"
[ 864] 5 => the size of the following string
[ 896] "test8"
[ 928] 128 => the offset of the 1st element of the sublist ("test9") relative to the beginning of the sublist (here [928]) so [1056]
[ 960] 192 => the offset of the 2nd element of the sublist ("test10") relative to the beginning of the sublist (here [928]) so [1120]
[ 992] 256 => the offset of the 3rd element of the sublist ("test11") relative to the beginning of the sublist (here [928]) so [1184]
[1024] 320 => the offset of the 4th element of the sublist ("test12") relative to the beginning of the sublist (here [928]) so [1248]
[1056] 5 => the size of the following string
[1088] "test9"
[1120] 6 => the size of the following string
[1152] "test10"
[1184] 6 => the size of the following string
[1216] "test11"
[1248] 6 => the size of the following string
[1280] "test12"
```

The list therefore occupies 41 memory words. The same thing in the form of a minified JSON string is 106 bytes, or 5 memory words (1 for the size and 4 for the content). Even if we add labels to the fields, it remains much cheaper than what we are currently doing. If we take it to the extreme, we could even make it smaller (by doing a homemade serialization), but the benefit is less clear, and we would lose readability.

The only advantage of the current solution is the ability to easily iterate over the list in Solidity, which we are not doing.
