### PR TITLE
Compliance proxy

### DIFF
--- a/contracts/compliance/ComplianceProxy.sol
+++ b/contracts/compliance/ComplianceProxy.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract ComplianceProxy is ERC1967Proxy {
+    constructor(address logic) payable ERC1967Proxy(logic, abi.encodeWithSignature("initialize()")) {}
+}


### PR DESCRIPTION
This contract is used to deploy a proxy pointing to our compliance core contract.
The point of using this contract instead of simply deploying a regular proxy directly is gas cost. Experimental testing showed it's cheaper to have the initializer call hardcoded.