### PR TITLE
Compliance requires overloading

### DIFF
--- a/contracts/CompliantContract.sol
+++ b/contracts/CompliantContract.sol
@@ -27,62 +27,28 @@ abstract contract CompliantContract {
         compliance = ICompliance(compliance_);
     }
 
-    /// @notice Requires compliance for a generic call
-    /// @param value The value parameter associated to the transaction
-    /// @param data An optional data parameter associated to the transaction
-    function requireGenericCallCompliance(uint256 value, bytes memory data) internal {
-        compliance.requireGenericCallCompliance(msg.sig, msg.sender, value, data);
+    /// @notice Requires compliance for a transaction
+    /// @param screening An array of addresses that should be available in the policy
+    /// @param values An array of token/amount that should be available in the policy
+    /// @dev Use 0x0 as a token address for native ETH
+    function requireCompliance(address[] memory screening, ICompliance.Value[] memory values) internal {
+        compliance.requireCompliance(msg.sender, msg.value, msg.data, screening, values);
     }
 
-    /// @notice Requires compliance for a native Eth transfer
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param value The value parameter associated to the transaction
-    function requireEthTransferCompliance(address from, address to, uint256 value) internal {
-        compliance.requireEthTransferCompliance(msg.sig, from, to, value);
+    /// @notice Requires compliance for a transaction
+    /// @param values An array of token/amount that should be available in the policy
+    /// @dev Use 0x0 as a token address for native ETH
+    function requireCompliance(ICompliance.Value[] memory values) internal {
+        compliance.requireCompliance(msg.sender, msg.value, msg.data, values);
     }
 
-    /// @notice Requires compliance for a native Eth transfer
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param value The value parameter associated to the transaction
-    /// @param data Any data associated to the transaction that isn't already included, but uniquely identifies the
-    ///             transaction. e.g. an invoice ID
-    function requireEthTransferWithDataCompliance(address from, address to, uint256 value, bytes memory data) internal {
-        compliance.requireEthTransferWithDataCompliance(msg.sig, from, to, value, data);
+    /// @notice Requires compliance for a transaction
+    /// @param screening An array of addresses that should be available in the policy
+    function requireCompliance(address[] memory screening) internal {
+        compliance.requireCompliance(msg.sender, msg.value, msg.data, screening);
     }
 
-    /// @notice Requires compliance for an ERC20 transfer
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param token The ERC20 token address
-    /// @param value The value parameter associated to the transaction
-    function requireErc20TransferCompliance(address from, address to, address token, uint256 value) internal {
-        compliance.requireErc20TransferCompliance(msg.sig, from, to, token, value);
-    }
-
-    /// @notice Requires compliance for an ERC20 transfer
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param token The ERC20 token address
-    /// @param value The value parameter associated to the transaction
-    /// @param data Any data associated to the transaction that isn't already included, but uniquely identifies the
-    ///             transaction. e.g. an invoice ID
-    function requireErc20TransferWithDataCompliance(
-        address from,
-        address to,
-        address token,
-        uint256 value,
-        bytes memory data
-    ) internal {
-        compliance.requireErc20TransferWithDataCompliance(msg.sig, from, to, token, value, data);
+    function requireCompliance() internal {
+        compliance.requireCompliance(msg.sender, msg.value, msg.data);
     }
 }

--- a/contracts/examples/ComplianceFirewall.sol
+++ b/contracts/examples/ComplianceFirewall.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {CompliantContract} from "../CompliantContract.sol";
+import {CompliantContract, ICompliance} from "../CompliantContract.sol";
 
 /// @title ComplianceFirewall
 /// @author Securely.id
@@ -10,15 +10,13 @@ import {CompliantContract} from "../CompliantContract.sol";
 contract ComplianceFirewall is CompliantContract {
     constructor(address compliance) CompliantContract(compliance) {}
 
-    /// @dev Sends orphan ethers to the default destination
-    receive() external payable {
-        payEthers(payable(address(0)));
-    }
-
     /// @notice Pay native ethers to a recipient
     /// @param destination The recipient address
     function payEthers(address payable destination) public payable {
-        requireEthTransferCompliance(msg.sender, destination, msg.value);
+        address[] memory addresses = new address[](2);
+        addresses[0] = msg.sender;
+        addresses[1] = destination;
+        requireCompliance(addresses);
         (bool sent, ) = destination.call{value: msg.value}("");
         require(sent, "Unable to pay ethers");
     }
@@ -28,7 +26,12 @@ contract ComplianceFirewall is CompliantContract {
     /// @param token The ERC20 token address
     /// @param amount The amount of tokens to pay
     function payTokens(address destination, address token, uint256 amount) external {
-        requireErc20TransferCompliance(tx.origin, destination, token, amount);
+        address[] memory addresses = new address[](2);
+        addresses[0] = msg.sender;
+        addresses[1] = destination;
+        ICompliance.Value[] memory values = new ICompliance.Value[](1);
+        values[0] = ICompliance.Value(token, amount);
+        requireCompliance(addresses, values);
         bool sent = IERC20(token).transferFrom(msg.sender, destination, amount);
         require(sent, "Unable to pay tokens");
     }

--- a/contracts/examples/CompliantTreasury.sol
+++ b/contracts/examples/CompliantTreasury.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {CompliantContract} from "../CompliantContract.sol";
+import {CompliantContract, ICompliance} from "../CompliantContract.sol";
 
 /// @title CompliantTreasury
 /// @author Securely.id
@@ -10,7 +10,7 @@ import {CompliantContract} from "../CompliantContract.sol";
 contract CompliantTreasury is CompliantContract {
     /// @dev mapping(owner => currency => amount)
     /// @dev Using currency = 0x0 for native ethers.
-    mapping(address => mapping(address => uint256)) private _treasury;
+    mapping(address => mapping(address => uint256)) internal _treasury;
 
     /// @dev For easy history tracking
     event Payment(address indexed source, address indexed destination, address indexed currency, uint256 amount);
@@ -45,7 +45,7 @@ contract CompliantTreasury is CompliantContract {
     /// @param amount The amount of tokens to transfer. Use 0 to transfer all
     /// @param currency The ERC20 token address. Use 0x0 for native ethers
     function transfer(address destination, address currency, uint256 amount) virtual public {
-        _requireTransferCompliance(msg.sender, msg.sender, currency, amount);
+        _requireTransferCompliance(msg.sender, destination, currency, amount);
         _move(msg.sender, destination, currency, amount);
         emit Transfer(msg.sender, destination, currency, amount);
     }
@@ -53,7 +53,7 @@ contract CompliantTreasury is CompliantContract {
     /// @notice Returns the amount of compliant eth/tokens owned by an internal account
     /// @param account The account to scan
     /// @param currency The currency to scan
-    function balanceOf(address account, address currency) public view returns (uint256 amount) {
+    function balanceOf(address account, address currency) external view returns (uint256 amount) {
         amount = _treasury[account][currency];
     }
 
@@ -70,10 +70,12 @@ contract CompliantTreasury is CompliantContract {
         address currency,
         uint256 amount
     ) internal {
-        if (currency == address(0))
-            requireEthTransferCompliance(source, destination, amount);
-        else
-            requireErc20TransferCompliance(source, destination, currency, amount);
+        address[] memory addresses = new address[](2);
+        addresses[0] = source;
+        addresses[1] = destination;
+        ICompliance.Value[] memory values = new ICompliance.Value[](1);
+        values[0] = ICompliance.Value(currency, amount);
+        requireCompliance(addresses, values);
     }
 
     /// @notice Receive funds from the msg.sender into an internal account

--- a/contracts/interfaces/ICompliance.sol
+++ b/contracts/interfaces/ICompliance.sol
@@ -6,71 +6,50 @@ pragma solidity ^0.8;
 /// @notice Simplified Compliance interface for compliance checks
 /// @dev This interface is used by the CompliantContract to interact with Securely's Compliance contract
 interface ICompliance {
-    /// @notice Requires compliance for a generic call
-    /// @param sig The msg.sig of the transaction
-    /// @param from The msg.sender of the transaction
-    /// @param value The value parameter associated to the transaction
-    /// @param data An optional data parameter associated to the transaction
-    function requireGenericCallCompliance(bytes4 sig, address from, uint256 value, bytes memory data) external;
+    /// @member token The ERC20 token used. Use 0x0 for native ethers
+    /// @member value The amount of tokens/wei
+    struct Value {
+        address token;
+        uint256 value;
+    }
 
-    /// @notice Requires compliance for a native Eth transfer
-    /// @param sig The msg.sig of the transaction
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param value The value parameter associated to the transaction
-    function requireEthTransferCompliance(bytes4 sig, address from, address to, uint256 value) external;
-
-    /// @notice Requires compliance for a native Eth transfer
-    /// @param sig The msg.sig of the transaction
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param value The value parameter associated to the transaction
-    /// @param data Any data associated to the transaction that isn't already included, but uniquely identifies the
-    ///             transaction. e.g. an invoice ID
-    function requireEthTransferWithDataCompliance(
-        bytes4 sig,
-        address from,
-        address to,
+    /// @notice Requires compliance for a transaction
+    /// @param sender The msg.sender of the transaction
+    /// @param value The msg.value of the transaction
+    /// @param data The msg.data of the transaction
+    /// @param screening A list of addresses to screen
+    /// @dev The first screening address is a source address
+    /// @dev The optional second screening address is a destination address
+    /// @dev There might be more addresses, labeled in the policy as SCREENING3, SCREENING4, ...
+    /// @param values An array of token/value to check in the policy
+    function requireCompliance(
+        address sender,
         uint256 value,
-        bytes memory data
+        bytes calldata data,
+        address[] memory screening,
+        Value[] memory values
     ) external;
 
-    /// @notice Requires compliance for an ERC20 transfer
-    /// @param sig The msg.sig of the transaction
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param token The ERC20 token address
-    /// @param value The value parameter associated to the transaction
-    function requireErc20TransferCompliance(
-        bytes4 sig,
-        address from,
-        address to,
-        address token,
-        uint256 value
-    ) external;
+    /// @notice Requires compliance for a transaction
+    /// @param sender The msg.sender of the transaction
+    /// @param value The msg.value of the transaction
+    /// @param data The msg.data of the transaction
+    /// @param screening A list of addresses to screen
+    /// @dev The first screening address is a source address
+    /// @dev The optional second screening address is a destination address
+    /// @dev There might be more addresses, labeled in the policy as SCREENING3, SCREENING4, ...
+    function requireCompliance(address sender, uint256 value, bytes calldata data, address[] memory screening) external;
 
-    /// @notice Requires compliance for an ERC20 transfer
-    /// @param sig The msg.sig of the transaction
-    /// @param from The sender of funds. Not necessarily the msg.sender of the transaction
-    /// @dev The from parameter is used for address screening purposes
-    /// @param to The receiver of funds. Not necessarily the dapp / the receiver of the transaction
-    /// @dev The to parameter is used for address screening purposes
-    /// @param token The ERC20 token address
-    /// @param value The value parameter associated to the transaction
-    /// @param data Any data associated to the transaction that isn't already included, but uniquely identifies the
-    ///             transaction. e.g. an invoice ID
-    function requireErc20TransferWithDataCompliance(
-        bytes4 sig,
-        address from,
-        address to,
-        address token,
-        uint256 value,
-        bytes memory data
-    ) external;
+    /// @notice Requires compliance for a transaction
+    /// @param sender The msg.sender of the transaction
+    /// @param value The msg.value of the transaction
+    /// @param data The msg.data of the transaction
+    /// @param values An array of token/value to check in the policy
+    function requireCompliance(address sender, uint256 value, bytes calldata data, Value[] memory values) external;
+
+    /// @notice Requires compliance for a transaction
+    /// @param sender The msg.sender of the transaction
+    /// @param value The msg.value of the transaction
+    /// @param data The msg.data of the transaction
+    function requireCompliance(address sender, uint256 value, bytes calldata data) external;
 }


### PR DESCRIPTION
Merge the requireXXXCompliance functions into one requireCompliance overloaded function.
The idea of having usecases tied to the compliance checking functions was bad and limited. This new way is more generic/evolutive.