### PR TITLE
Hardhat config

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -6,7 +6,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 200,
+        runs: 1000000,
       },
       evmVersion: "cancun",
     },


### PR DESCRIPTION
Update the runs parameter of the solidity optimizer in the hardhat config.
The runs parameter represents the estimated number of times an opcode is estimated to run in the SC's lifetime. 200 is way off. One million is more realistic and should be high enough so that any higher value won't change anything anyway.