### PR TITLE
Whitelisted treasury hotfix

### DIFF
--- a/contracts/examples/WhitelistedCompliantTreasury.sol
+++ b/contracts/examples/WhitelistedCompliantTreasury.sol
@@ -40,7 +40,7 @@ contract WhitelistedCompliantTreasury is AccessControl, CompliantTreasury {
     /// @param currency The ERC20 token address. Use 0x0 for native ethers
     function transfer(address destination, address currency, uint256 amount) virtual public override {
         if (!hasRole(WHITELISTED_ROLE, msg.sender))
-            _requireTransferCompliance(msg.sender, msg.sender, currency, amount);
+            _requireTransferCompliance(msg.sender, destination, currency, amount);
         _move(msg.sender, destination, currency, amount);
         emit Transfer(msg.sender, destination, currency, amount);
     }


### PR DESCRIPTION
The destination address in the transfer function of the whitelisted compliant treasury was wrongly set to msg.sender. It's now using the correct address.