### PR TITLE
Dedicated sender slot

### DIFF
--- a/contracts/interfaces/IComplianceOracle.sol
+++ b/contracts/interfaces/IComplianceOracle.sol
@@ -48,11 +48,17 @@ interface IComplianceOracle {
     function issueVerdict(address dapp, bytes32 partialHash, bool approved) external;
 
     /// @notice Gets the compliance status of a transaction
+    /// @param sender The msg.sender of the transaction
     /// @param dapp The dapp address
     /// @param partialHash The partial hash of the transaction
     /// @param wallets The list of addresses used in ICompliance.requireCompliance
     /// @return status the status of the transaction
-    function getStatus(address dapp, bytes32 partialHash, address[] memory wallets) external view returns (Status);
+    function getStatus(
+        address sender,
+        address dapp,
+        bytes32 partialHash,
+        address[] memory wallets
+    ) external view returns (Status);
 
     /// @notice Computes a partial hash based on a transaction's parameters
     /// @param sender The msg.sender of the transaction


### PR DESCRIPTION
msg.sender is no longer in wallets by default, and therefore must be passed along to getStatus, so onchain checks can be performed on this address aswell.